### PR TITLE
fix: simplify language server cleanup and improve dotnet error message

### DIFF
--- a/src/bicep.rs
+++ b/src/bicep.rs
@@ -34,12 +34,9 @@ impl BicepExtension {
     fn dotnet_binary_path(&mut self, worktree: &zed::Worktree) -> Result<String> {
         let dotnet_path = match &self.dotnet_binary_path {
             Some(path) if fs::metadata(path).map_or(false, |stat| stat.is_file()) => path.clone(),
-            Some(path) => worktree
-                .which(path.clone().as_str())
-                .ok_or_else(|| "DotNet 8.0+ must be installed for Bicep")?,
-            None => worktree
+            _ => worktree
                 .which("dotnet")
-                .ok_or_else(|| "DotNet 8.0+ must be installed for Bicep")?,
+                .ok_or_else(|| "dotnet not found. Install the .NET SDK 8.0+ from https://dotnet.microsoft.com/download. Note: the standalone Bicep CLI is not sufficient.")?,
         };
         self.dotnet_binary_path = Some(dotnet_path.clone());
         Ok(dotnet_path)
@@ -83,15 +80,18 @@ impl BicepExtension {
             )
             .map_err(|err| format!("download error {}", err))?;
 
-            make_all_files_executable(&version_dir)?;
-
-            // Ensure the binary exists
+            // Clean up old versions
             let entries =
                 fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
             for entry in entries {
                 let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
                 if entry.file_name().to_str() != Some(&version_dir) {
-                    fs::remove_dir_all(entry.path()).ok();
+                    let path = entry.path();
+                    if path.is_dir() {
+                        fs::remove_dir_all(&path).ok();
+                    } else {
+                        fs::remove_file(&path).ok();
+                    }
                 }
             }
         }
@@ -103,23 +103,6 @@ impl BicepExtension {
             .to_string();
         Ok(abs_path)
     }
-}
-
-fn make_all_files_executable(dir: &str) -> Result<(), String> {
-    fn recurse(path: &str) -> Result<(), String> {
-        let metadata = fs::metadata(path).map_err(|e| format!("metadata error: {e}"))?;
-        if metadata.is_dir() {
-            for entry in fs::read_dir(path).map_err(|e| format!("read_dir error: {e}"))? {
-                let entry = entry.map_err(|e| format!("entry error: {e}"))?;
-                recurse(&entry.path().to_string_lossy())?;
-            }
-        } else if metadata.is_file() {
-            zed::make_file_executable(path)
-                .map_err(|e| format!("make_file_executable error: {e}"))?;
-        }
-        Ok(())
-    }
-    recurse(dir.as_ref())
 }
 
 zed::register_extension!(BicepExtension);


### PR DESCRIPTION
## Summary

Addresses the root cause of #35 and cleans up unnecessary code in the language server setup.

## Changes

### Remove `make_all_files_executable`

The function recursively set the executable bit on every file in the extracted language server directory. This was never necessary: the command run is `dotnet ... Bicep.LangServer.dll`, where `dotnet` *reads* the DLL — it does not execute it. Files extracted from the zip with default permissions (`0o644`) work correctly, as confirmed by Zed logs showing the language server starting and operating successfully.

Removing this brings the extension in line with the standard pattern used by other Zed extensions (e.g. GLSL, Proto), which only call `zed::make_file_executable` on actual executable binaries.

### Improve old version cleanup

The cleanup loop previously called `fs::remove_dir_all` on **all** non-current directory entries. This silently failed (via `.ok()`) for any loose files. The loop now correctly dispatches:
- Directories → `fs::remove_dir_all`
- Files → `fs::remove_file`

### Simplify `dotnet_binary_path` cached-path logic

The middle `Some(path)` match arm called `worktree.which()` on a previously-resolved absolute path, which is redundant (absolute paths are not resolved by `which`). Collapsed into a single `_` fallback that always re-resolves via `which("dotnet")` when the cached path is no longer valid on disk.

### Improve `dotnet` error message (fixes #35)

The previous message `"DotNet 8.0+ must be installed for Bicep"` was ambiguous. The reporter in #35 had the standalone Bicep CLI (`bicep -v` worked) but not the .NET SDK, which is what this extension requires to run the language server. The new message explicitly states:

> `dotnet not found. Install the .NET SDK 8.0+ from https://dotnet.microsoft.com/download. Note: the standalone Bicep CLI is not sufficient.`
